### PR TITLE
Add --scheduled, --verbose, and no user.

### DIFF
--- a/Docs.md
+++ b/Docs.md
@@ -3,7 +3,7 @@
 ## How to use
 You can use Instagram2Fedi via docker or just like a python script
 
-** Note: ** _Since somewhen it's seems not possible to fetch any data from instagram anonymously (maybe i'm wrong and there's a solution, I'll be very happy to know about it). Due that you unfortunately have to had an instagram accound and provide login and password to this script_
+** Note: ** _Credentials can be complicated.  Running without Instagram credentials (`user-name` and `user-password`) appears to work for a short period of time but will, eventually, fail.  Providing credentials will work unless Instagram issues a challenge.  Recommend leaving `user-name` blank if running as a scheduled job (`--scheduled`) and providing them otherwise._
 ### With Docker 🐋
 
 Specify your variables in `./env.sh` and then run `./run.sh`
@@ -65,6 +65,14 @@ If theres more than one new post, sets with which time interval should it post t
 ---
 
 `--use-docker` - If you're running it via docker container, set to `1` or `True`
+
+---
+
+`--scheduled` - If set, Instagram2Fedi runs once instead of sleeping for `check-interval` and running forever.  This is intended for use as a `cron` job.  No additional parameter is needed, just add `--scheduled`.
+
+---
+
+`--verbose` - If set, output all logs including secrets.  No additional parameter is needed, just add `--scheduled`.
 
 
 ## Default values ⚙

--- a/src/arguments.py
+++ b/src/arguments.py
@@ -11,17 +11,30 @@ instance = os.environ.get("I2M_INSTANCE")
 token = os.environ.get("I2M_TOKEN")
 check_interval = os.environ.get("I2M_CHECK_INTERVAL") #1 hour 
 post_interval = os.environ.get("I2M_POST_INTERVAL") #1 hour 
-use_mastodon = os.environ.get("I2M_USE_MASTODON") #max carouse is 4, if there's no limit set to -1
+use_mastodon = os.environ.get("I2M_USE_MASTODON") #max carousel is 4, if there's no limit set to -1
 fetch_count = os.environ.get("I2M_FETCH_COUNT") # how many instagram posts to fetch per check_interval
-print('instagram', instagram_user)
-print('instagram', instance)
-print(token)
-print(check_interval)
-print(post_interval)
-print(use_mastodon)
-print(fetch_count)
-print(user_name)
-print(user_password)
+if os.environ.get("I2M_SCHEDULED") == "True":
+    scheduled_run = True # run continuously (if False) or a single time (if True)
+else:
+    scheduled_run = False
+if os.environ.get("I2M_VERBOSE") == "True": # verbose output
+    verbose_output = True
+else:
+    verbose_output = False
+
+if verbose_output:
+    print('instagram', instagram_user)
+    print('instagram', instance)
+    print(token)
+    print(check_interval)
+    print(post_interval)
+    print(use_mastodon)
+    print(fetch_count)
+    print(user_name)
+    print(user_password)
+    print(scheduled_run)
+    print(verbose_output)
+
 
 
 def flags(args, defaults):
@@ -52,6 +65,12 @@ def flags(args, defaults):
             defaults["user-name"] = args[count + 1]
         elif (args[count] == "--user-password"):
             defaults["user-password"] = args[count + 1]
+        elif (args[count] == "--scheduled"):
+            defaults["scheduled"] = True
+            count -= 1
+        elif (args[count] == "--verbose"):
+            defaults["verbose"] = True
+            count -= 1
 
         else:
             print(Fore.RED + '❗ -> Wrong Argument Name!...')
@@ -75,7 +94,8 @@ def process_arguments(args, defaults):
     defaults["post-interval"] = int(post_interval) if post_interval != '' and post_interval else None
     defaults["fetch-count"] = int(fetch_count) if fetch_count != '' and fetch_count else None
     defaults["carousel-limit"] = int(use_mastodon) if use_mastodon != '' and use_mastodon else None
-    defaults["carousel-limit"] = int(use_mastodon) if use_mastodon != '' and use_mastodon else None
+    defaults["scheduled"] = bool(scheduled_run) if scheduled_run else False
+    defaults["verbose"] = bool(verbose_output) if verbose_output else False
     #print(Fore.RED + '❗ -> Missing Argument ')
     #print(Style.RESET_ALL)
     #print(datetime.datetime.now())

--- a/src/main.py
+++ b/src/main.py
@@ -13,9 +13,6 @@ from arguments import process_arguments
 from network import get_new_posts
 
 
-
-print(sys.argv)
-print("ARGUMENTS")
 default_settings = {
     "instance": None,
     "instagram-user": None,
@@ -23,14 +20,21 @@ default_settings = {
     "user-password": None,
     "token": None,
     "check-interval": 3600,
-    "post-interval": 3600,
+    "post-interval": 60,
     "fetch-count" : 10,
     "carousel-limit": 4,
+    "scheduled": False,
+    "verbose": False
 }
 
 settings = process_arguments(sys.argv, default_settings)
 
-print('SETTINGS' , settings)
+verbose = settings["verbose"]
+
+if verbose:
+    print("ARGUMENTS")
+    print(sys.argv)
+    print('SETTINGS' , settings)
 
 agree = [1, True, "true", "True", "yes", "Yes"]
 if (os.environ.get("USE_DOCKER")):
@@ -52,6 +56,8 @@ post_interval =  settings["post-interval"]#1m
 
 using_mastodon = settings["carousel-limit"] > 0;
 mastodon_carousel_size = settings["carousel-limit"]
+scheduled = settings["scheduled"]
+
 
 user = {
     "name": settings["user-name"],
@@ -68,4 +74,6 @@ mastodon = Mastodon(
 )
 while True:
     get_new_posts(mastodon, mastodon_carousel_size, post_limit, id_filename, using_mastodon, mastodon_carousel_size, post_interval, fetched_user, user)
+    if scheduled:
+        break
     time.sleep(time_interval_sec)

--- a/src/main.py
+++ b/src/main.py
@@ -39,6 +39,8 @@ if verbose:
 agree = [1, True, "true", "True", "yes", "Yes"]
 if (os.environ.get("USE_DOCKER")):
     id_filename = "/app/already_posted.txt"
+elif (os.environ.get("USE_KUBERNETES")):
+    id_filename = "/data/already_posted.txt"
 else:
     id_filename = "./already_posted.txt"
 

--- a/src/network.py
+++ b/src/network.py
@@ -14,8 +14,10 @@ def get_instagram_user(user, fetched_user):
     print(Fore.GREEN + 'TEST 🚀 > Connecting to Instagram...')
     print(Style.RESET_ALL)
     print(datetime.datetime.now())
-    print("USER USER USER!!!!!!!!!!!!!1", user)
-    L.login(user["name"], user["password"])
+
+    if user["name"] != None:
+        print("USER USER USER!!!!!!!!!!!!!", user["name"])
+        L.login(user["name"], user["password"])
     return Profile.from_username(L.context, fetched_user)
 
 def get_image(url):
@@ -62,7 +64,7 @@ def toot(urls, title, mastodon, fetched_user ):
         ids = []
         for url in urls:
             ids.append(upload_image_to_mastodon(url, mastodon))
-        post_text = str(title) + "\n" + "crossposted from https://instagram.com/"+fetched_user # creating post text
+        post_text = str(title) + "\n"  # creating post text
         post_text = post_text[0:1000]
         if(ids):
             print(ids)


### PR DESCRIPTION
I'm using this as a cron job instead of a continuous bot.  I added a flag (`--scheduled`) and an env var (`I2M_SCHEDULED`) that run Instagram2Fedi a single time then exits instead of running it continuously.

Additionally, I added `--verbose`/`I2M_VERBOSE` so that secrets like `user-password` and `token` aren't sent to stdout by default.  

Finally, it appears that not logging on works, at least for awhile, before IG starts forcing a login.  If `user-name` is None, I added an `if` block to skip IG login.  This has worked for me in my cron job but, if I leave the bot running, I get an auth error after a few runs.